### PR TITLE
Ensure Consistency in Test Cases by Removing Date-Dependent Test

### DIFF
--- a/Microservices/Speisekarte/src/test/java/online/dhbw_studentprojekt/msspeisekarte/service/SpeisekarteServiceTest.java
+++ b/Microservices/Speisekarte/src/test/java/online/dhbw_studentprojekt/msspeisekarte/service/SpeisekarteServiceTest.java
@@ -205,20 +205,6 @@ public class SpeisekarteServiceTest {
         verify(speisekarteClient, never()).getSpeisekarte(any());
     }
 
-    @Test
-    void testGetSpeisekarte_NoDateProvided() {
-        // Arrange
-        when(speisekarteClient.getSpeisekarte(any())).thenReturn(mockHtml);
-
-        // Act
-        Speisekarte result = speisekarteService.getSpeisekarte(Optional.empty());
-
-        // Assert
-        assertNotNull(result, "Speisekarte should not be null when no date is provided");
-        verify(speisekarteClient, times(1)).getSpeisekarte(any());
-        assertEquals(speisekarte, result);
-    }
-
     // The following tests for prepareFormData Method
     // Commented out because of private method
     // Decide later if needed


### PR DESCRIPTION
The test case has been removed to ensure consistency across tests, regardless of the current date.

This case was redundant since separate tests already cover valid weekday and weekend behavior, verifying that when the Datum variable is empty, the current date is correctly provided.